### PR TITLE
fix(schema): remove required constraint over 'endpoint'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 lerna-debug.log
 node_modules/
-
+npm-debug.log

--- a/packages/schemas/BlockConfig.json
+++ b/packages/schemas/BlockConfig.json
@@ -29,7 +29,7 @@
         "Cela définit ce qui est nécessaire pour le rendering du Block par le CMS. À tout moment il ne peut y avoir plus de `maxItems` configurations simultanément disponible pour un Block.",
       "items": {
         "type": "object",
-        "required": ["version", "endpoint"],
+        "required": ["version"],
         "properties": {
           "version": {
             "$ref":


### PR DESCRIPTION
See #19 
Remove the 'required' constraint over the endpoint field.
Now you may omit 'endpoint' completely but once defined you have to define all elements of 'endpoint' as those fields are required by 'endpoint'.
