### PR TITLE
feat(schema): complete ui schema definition

### DIFF
--- a/packages/documentation/BlockConfig.md
+++ b/packages/documentation/BlockConfig.md
@@ -14,7 +14,8 @@ Le BlockConfig permet de spécifier au CMS les Blocks à exposer au niveau du Pa
         "pure": false,
         "parameters": [
           {}
-        ]
+        ],
+        "ui": []
       },
       "templates": [
         {
@@ -130,11 +131,13 @@ Relies on OpenAPI v2.0 because v3.0 is missing official JSON Schema (https://git
 
 ### `.configurations[].endpoint.ui`
 
+Declaration des differents champs proposés à la configuration dans le Page Builder.
+
+### `.configurations[].endpoint.ui[]`
+
+Regroupement en section _(rattaché à un nom et un identifiant)_ pour faciliter l'organisation par groupe d'intérêt.
+
 ### `.configurations[].templates`
-
-
-
-
 
 *Type*: array
 

--- a/packages/documentation/BlockConfig.md
+++ b/packages/documentation/BlockConfig.md
@@ -14,8 +14,7 @@ Le BlockConfig permet de spécifier au CMS les Blocks à exposer au niveau du Pa
         "pure": false,
         "parameters": [
           {}
-        ],
-        "ui": []
+        ]
       },
       "templates": [
         {
@@ -131,13 +130,11 @@ Relies on OpenAPI v2.0 because v3.0 is missing official JSON Schema (https://git
 
 ### `.configurations[].endpoint.ui`
 
-Declaration des differents champs proposés à la configuration dans le Page Builder.
-
-### `.configurations[].endpoint.ui[]`
-
-Regroupement en section _(rattaché à un nom et un identifiant)_ pour faciliter l'organisation par groupe d'intérêt.
-
 ### `.configurations[].templates`
+
+
+
+
 
 *Type*: array
 

--- a/packages/schemas/BlockConfig.json
+++ b/packages/schemas/BlockConfig.json
@@ -177,7 +177,7 @@
           },
           "external": {
             "type": "object",
-            "required": ["parameters", "ui"],
+            "required": ["parameters"],
             "properties": {
               "parameters": {
                 "type": "array",
@@ -190,10 +190,6 @@
                     "see OpenAPI Parameters / JSON Schema Specification Wright Draft 00 (aka Draft 5)"
                   ]
                 }
-              },
-              "ui": {
-                "$ref":
-                  "https://raw.githubusercontent.com/Ouest-France/platform/master/packages/schemas/defs.json#/definitions/UISchema"
               },
               "headers": {
                 "type": "array",

--- a/packages/schemas/BlockConfig.test.js
+++ b/packages/schemas/BlockConfig.test.js
@@ -42,6 +42,7 @@ describe('BlockConfig', () => {
                   "title": "Technique",
                   "properties": {
                     "role": {
+                      "description": "Role à qui reviendra la charge d'éditer ce block",
                       "type": "string",
                       "title": "Role",
                       "enum": ["ADMIN", "WEBMASTER", "ANONYME"]
@@ -54,27 +55,29 @@ describe('BlockConfig', () => {
                   "properties": {
                     "inseeCode": {
                       "type": "string",
+                      "description": "code insee de la ville ciblée par le block",
                       "title": "Foo",
                       "maxLength": 10,
-                      "regex": "[0-9]{5}"
+                      "pattern": "[0-9]{5}"
                     },
                     "offset": {
                       "type": "number",
+                      "description": "decalage de la liste d'article à récupérer",
                       "title": "Decalage",
-                      "min": -10,
-                      "max": 10
+                      "minimum": 0,
+                      "maximum": 100
                     },
                     "isVisible": {
                       "type": "boolean",
-                      "title": "Afficher ?",
+                      "title": "Afficher",
                       "description": "Permet de controler l'affichage du block dans une page. L'utilisation d'expression permet de conditionner cet affichage, par exemple '${PAGE} <= 1'"
                     },
                     "size": {
                       "type": "string",
                       "title": "Nombre d'article",
                       "description": "Correspond au nombre d'article à aficher sur la première page d'une liste d'article",
-                      "min": 0,
-                      "max": 100
+                      "minimum": 0,
+                      "maximum": 100
                     }
                   },
                   required: [ 'inseeCode', 'size' ]

--- a/packages/schemas/BlockConfig.test.js
+++ b/packages/schemas/BlockConfig.test.js
@@ -36,23 +36,20 @@ describe('BlockConfig', () => {
                 required: true,
               },
             ],
-            ui: [
-              {
-                "id": "admin",
-                "form": {
+            ui: {
+              sections: [
+                {
                   "title": "Technique",
                   "properties": {
                     "role": {
                       "type": "string",
                       "title": "Role",
-                      "enum": [ "ADMIN", "WEBMASTER", "ANONYME" ]
+                      "enum": ["ADMIN", "WEBMASTER", "ANONYME"]
                     }
-                  }
-                }
-              },
-              {
-                "id": "param",
-                "form": {
+                  },
+                  required: [ 'role' ]
+                },
+                {
                   "title": "Paramètres",
                   "properties": {
                     "inseeCode": {
@@ -79,10 +76,11 @@ describe('BlockConfig', () => {
                       "min": 0,
                       "max": 100
                     }
-                  }
+                  },
+                  required: [ 'inseeCode', 'size' ]
                 }
-              }
-            ]
+              ]
+            }
           },
           templates: [
             {
@@ -101,7 +99,7 @@ describe('BlockConfig', () => {
           ],
           external: {
             parameters: [],
-            ui: [],
+            ui: {},
           },
         },
       ],
@@ -127,12 +125,11 @@ describe('BlockConfig', () => {
             method: 'GET',
             pure: false,
             parameters: [],
-            ui: [],
+            ui: {},
           },
           templates: [],
           external: {
             parameters: [],
-            ui: [],
           },
         },
       ],
@@ -174,20 +171,18 @@ describe('BlockConfig', () => {
               method: 'GET',
               pure: false,
               parameters: [],
-              ui: [
-                {
-                  "id": "param",
-                  "form": {
-                    "title": "Paramètres",
+              ui: {
+                sections: [
+                  {
+                    "title": "param",
                     "properties": {}
                   }
-                }
-              ]
+                ]
+              }
             },
             templates: [],
             external: {
               parameters: [],
-              ui: []
             },
           },
         ],
@@ -195,85 +190,8 @@ describe('BlockConfig', () => {
       expect(isValid).toBe(false);
       expect(validate.errors).toHaveLength(1);
       expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui[0].form.properties",
+        { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties",
           "keyword": "minProperties",
-        });
-    });
-
-    it('throw an error if UI section has no id', () => {
-
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: [
-                {
-                  "form": {
-                    "title": "Paramètres",
-                    "properties": {
-                      "inseeCode": {
-                        "type": "string",
-                        "title": "Code INSEE"
-                      }
-                    }
-                  }
-                }
-              ]
-            },
-            templates: [],
-            external: {
-              parameters: [],
-              ui: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toHaveLength(1);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui[0]",
-          "keyword": "required",
-          "params": { "missingProperty": "id" },
-        });
-    });
-
-    it('throw an error if UI section has no form', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: [{id: "xxx"}]
-            },
-            templates: [],
-            external: {
-              parameters: [],
-              ui: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toHaveLength(1);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui[0]",
-          "keyword": "required",
-          "params": { "missingProperty": "form" },
         });
     });
 
@@ -290,14 +208,15 @@ describe('BlockConfig', () => {
               method: 'GET',
               pure: false,
               parameters: [],
-              ui: [{
-                id: "param",
-                form: {
-                  type: "string",
-                  title: "insee",
-                  other: "a value"
-                }
-              }]
+              ui: {
+                sections: [
+                  {
+                    type: "string",
+                    title: "insee",
+                    other: "a value"
+                  }
+                ]
+              }
             },
             templates: [],
             external: {
@@ -309,7 +228,7 @@ describe('BlockConfig', () => {
       });
       expect(isValid).toBe(false);
       expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui[0].form",
+        { "dataPath": ".configurations[0].endpoint.ui.sections[0]",
           "keyword": "additionalProperties",
         });
     });
@@ -327,10 +246,9 @@ describe('BlockConfig', () => {
               method: 'GET',
               pure: false,
               parameters: [],
-              ui: [
-                {
-                  "id": "param",
-                  "form": {
+              ui: {
+                sections: [
+                  {
                     "title": "Paramètres",
                     "properties": {
                       "inseeCode": {
@@ -338,13 +256,12 @@ describe('BlockConfig', () => {
                       }
                     }
                   }
-                }
-              ]
+                ]
+              }
             },
             templates: [],
             external: {
               parameters: [],
-              ui: []
             },
           },
         ],
@@ -352,7 +269,7 @@ describe('BlockConfig', () => {
       expect(isValid).toBe(false);
       expect(validate.errors).toHaveLength(1);
       expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui[0].form.properties['inseeCode']",
+        { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
           "keyword": "required",
           "params": { "missingProperty": "title" },
         });
@@ -371,10 +288,9 @@ describe('BlockConfig', () => {
               method: 'GET',
               pure: false,
               parameters: [],
-              ui: [
-                {
-                  "id": "param",
-                  "form": {
+              ui: {
+                sections: [
+                  {
                     "title": "Paramètres",
                     "properties": {
                       "inseeCode": {
@@ -382,13 +298,12 @@ describe('BlockConfig', () => {
                       }
                     }
                   }
-                }
-              ]
+                ]
+              }
             },
             templates: [],
             external: {
-              parameters: [],
-              ui: []
+              parameters: []
             },
           },
         ],
@@ -396,7 +311,7 @@ describe('BlockConfig', () => {
       expect(isValid).toBe(false);
       expect(validate.errors).toHaveLength(1);
       expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui[0].form.properties['inseeCode']",
+        { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
           "keyword": "required",
           "params": { "missingProperty": "type" },
         });
@@ -416,10 +331,9 @@ describe('BlockConfig', () => {
                 method: 'GET',
                 pure: false,
                 parameters: [],
-                ui: [
-                  {
-                    "id": "param",
-                    "form": {
+                ui: {
+                  sections: [
+                    {
                       "title": "Paramètres",
                       "properties": {
                         "inseeCode": {
@@ -428,20 +342,19 @@ describe('BlockConfig', () => {
                         }
                       }
                     }
-                  }
-                ]
+                  ]
+                }
               },
               templates: [],
               external: {
-                parameters: [],
-                ui: []
+                parameters: []
               },
             },
           ],
         });
         expect(isValid).toBe(false);
         expect(validate.errors[0]).toMatchObject(
-          { "dataPath": ".configurations[0].endpoint.ui[0].form.properties['inseeCode'].type",
+          { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode'].type",
             "keyword": "enum"
           });
       });

--- a/packages/schemas/BlockConfig.test.js
+++ b/packages/schemas/BlockConfig.test.js
@@ -36,15 +36,53 @@ describe('BlockConfig', () => {
                 required: true,
               },
             ],
-            ui: {
-              threshold: {
-                'ui:autofocus': true,
-                'ui:emptyValue': '10200',
-                'ui:title': 'Bitcoin threshold',
-                'ui:description':
-                  'At which point should the Bitcoin threshold should be defined',
+            ui: [
+              {
+                "id": "admin",
+                "form": {
+                  "title": "Technique",
+                  "properties": {
+                    "role": {
+                      "type": "string",
+                      "title": "Role",
+                      "enum": [ "ADMIN", "WEBMASTER", "ANONYME" ]
+                    }
+                  }
+                }
               },
-            },
+              {
+                "id": "param",
+                "form": {
+                  "title": "Paramètres",
+                  "properties": {
+                    "inseeCode": {
+                      "type": "string",
+                      "title": "Foo",
+                      "maxLength": 10,
+                      "regex": "[0-9]{5}"
+                    },
+                    "offset": {
+                      "type": "number",
+                      "title": "Decalage",
+                      "min": -10,
+                      "max": 10
+                    },
+                    "isVisible": {
+                      "type": "boolean",
+                      "title": "Afficher ?",
+                      "description": "Permet de controler l'affichage du block dans une page. L'utilisation d'expression permet de conditionner cet affichage, par exemple '${PAGE} <= 1'"
+                    },
+                    "size": {
+                      "type": "string",
+                      "title": "Nombre d'article",
+                      "description": "Correspond au nombre d'article à aficher sur la première page d'une liste d'article",
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                }
+              }
+            ]
           },
           templates: [
             {
@@ -63,7 +101,7 @@ describe('BlockConfig', () => {
           ],
           external: {
             parameters: [],
-            ui: {},
+            ui: [],
           },
         },
       ],
@@ -89,12 +127,12 @@ describe('BlockConfig', () => {
             method: 'GET',
             pure: false,
             parameters: [],
-            ui: {},
+            ui: [],
           },
           templates: [],
           external: {
             parameters: [],
-            ui: {},
+            ui: [],
           },
         },
       ],
@@ -115,5 +153,298 @@ describe('BlockConfig', () => {
       'https://raw.githubusercontent.com/Ouest-France/platform/master/packages/schemas/BlockConfig.json'
     );
     expect(validate({ internal: {}, external: {} })).toBe(false);
+  });
+
+  describe('throw an error if UI is invalid', () => {
+    const validate = require('.').getSchema(
+      'https://raw.githubusercontent.com/Ouest-France/platform/master/packages/schemas/BlockConfig.json'
+    );
+
+    it('throw an error if UI section has no properties', () => {
+
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: [
+                {
+                  "id": "param",
+                  "form": {
+                    "title": "Paramètres",
+                    "properties": {}
+                  }
+                }
+              ]
+            },
+            templates: [],
+            external: {
+              parameters: [],
+              ui: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toHaveLength(1);
+      expect(validate.errors[0]).toMatchObject(
+        { "dataPath": ".configurations[0].endpoint.ui[0].form.properties",
+          "keyword": "minProperties",
+        });
+    });
+
+    it('throw an error if UI section has no id', () => {
+
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: [
+                {
+                  "form": {
+                    "title": "Paramètres",
+                    "properties": {
+                      "inseeCode": {
+                        "type": "string",
+                        "title": "Code INSEE"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            templates: [],
+            external: {
+              parameters: [],
+              ui: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toHaveLength(1);
+      expect(validate.errors[0]).toMatchObject(
+        { "dataPath": ".configurations[0].endpoint.ui[0]",
+          "keyword": "required",
+          "params": { "missingProperty": "id" },
+        });
+    });
+
+    it('throw an error if UI section has no form', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: [{id: "xxx"}]
+            },
+            templates: [],
+            external: {
+              parameters: [],
+              ui: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toHaveLength(1);
+      expect(validate.errors[0]).toMatchObject(
+        { "dataPath": ".configurations[0].endpoint.ui[0]",
+          "keyword": "required",
+          "params": { "missingProperty": "form" },
+        });
+    });
+
+    it('throw an error if UI section has unexpected property', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: [{
+                id: "param",
+                form: {
+                  type: "string",
+                  title: "insee",
+                  other: "a value"
+                }
+              }]
+            },
+            templates: [],
+            external: {
+              parameters: [],
+              ui: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors[0]).toMatchObject(
+        { "dataPath": ".configurations[0].endpoint.ui[0].form",
+          "keyword": "additionalProperties",
+        });
+    });
+
+    it('throw an error if UI property has no title', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: [
+                {
+                  "id": "param",
+                  "form": {
+                    "title": "Paramètres",
+                    "properties": {
+                      "inseeCode": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            templates: [],
+            external: {
+              parameters: [],
+              ui: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toHaveLength(1);
+      expect(validate.errors[0]).toMatchObject(
+        { "dataPath": ".configurations[0].endpoint.ui[0].form.properties['inseeCode']",
+          "keyword": "required",
+          "params": { "missingProperty": "title" },
+        });
+    });
+
+    it('throw an error if UI property has no type', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: [
+                {
+                  "id": "param",
+                  "form": {
+                    "title": "Paramètres",
+                    "properties": {
+                      "inseeCode": {
+                        "title": "Code INSEE"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            templates: [],
+            external: {
+              parameters: [],
+              ui: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toHaveLength(1);
+      expect(validate.errors[0]).toMatchObject(
+        { "dataPath": ".configurations[0].endpoint.ui[0].form.properties['inseeCode']",
+          "keyword": "required",
+          "params": { "missingProperty": "type" },
+        });
+    });
+
+    ['array', 'object', 'null'].forEach(type => {
+      it(`throw an error if UI property has type ${type}`, () => {
+        const isValid = validate({
+          name: 'cms-block-provider-empty',
+          type: 'Display',
+          labels: [],
+          configurations: [
+            {
+              version: '1.0.0',
+              endpoint: {
+                url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+                method: 'GET',
+                pure: false,
+                parameters: [],
+                ui: [
+                  {
+                    "id": "param",
+                    "form": {
+                      "title": "Paramètres",
+                      "properties": {
+                        "inseeCode": {
+                          "type": type,
+                          "title": "Code INSEE"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              templates: [],
+              external: {
+                parameters: [],
+                ui: []
+              },
+            },
+          ],
+        });
+        expect(isValid).toBe(false);
+        expect(validate.errors[0]).toMatchObject(
+          { "dataPath": ".configurations[0].endpoint.ui[0].form.properties['inseeCode'].type",
+            "keyword": "enum"
+          });
+      });
+    });
   });
 });

--- a/packages/schemas/BlockConfig.test.js
+++ b/packages/schemas/BlockConfig.test.js
@@ -45,7 +45,9 @@ describe('BlockConfig', () => {
                       "description": "Role à qui reviendra la charge d'éditer ce block",
                       "type": "string",
                       "title": "Role",
-                      "enum": ["ADMIN", "WEBMASTER", "ANONYME"]
+                      "enum": ["ADMIN", "WEBMASTER", "ANONYME"],
+                      "minLength": 0,
+                      "maxLength": 10
                     }
                   },
                   required: [ 'role' ]
@@ -57,6 +59,7 @@ describe('BlockConfig', () => {
                       "type": "string",
                       "description": "code insee de la ville ciblée par le block",
                       "title": "Foo",
+                      "minLength": 0,
                       "maxLength": 10,
                       "pattern": "[0-9]{5}"
                     },
@@ -68,16 +71,16 @@ describe('BlockConfig', () => {
                       "maximum": 100
                     },
                     "isVisible": {
-                      "type": "boolean",
                       "title": "Afficher",
-                      "description": "Permet de controler l'affichage du block dans une page. L'utilisation d'expression permet de conditionner cet affichage, par exemple '${PAGE} <= 1'"
+                      "description": "Permet de controler l'affichage du block dans une page. L'utilisation d'expression permet de conditionner cet affichage, par exemple '${PAGE} <= 1'",
+                      "type": "boolean"
                     },
                     "size": {
                       "type": "string",
                       "title": "Nombre d'article",
                       "description": "Correspond au nombre d'article à aficher sur la première page d'une liste d'article",
-                      "minimum": 0,
-                      "maximum": 100
+                      "minLength": 0,
+                      "maxLength": 10
                     }
                   },
                   required: [ 'inseeCode', 'size' ]
@@ -255,7 +258,10 @@ describe('BlockConfig', () => {
                     "title": "Paramètres",
                     "properties": {
                       "inseeCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "bla bla",
+                        "minLength": 0,
+                        "maxLength": 10
                       }
                     }
                   }
@@ -297,7 +303,10 @@ describe('BlockConfig', () => {
                     "title": "Paramètres",
                     "properties": {
                       "inseeCode": {
-                        "title": "Code INSEE"
+                        "title": "Code INSEE",
+                        "description": "bla bla",
+                        "minLength": 0,
+                        "maxLength": 10
                       }
                     }
                   }
@@ -312,12 +321,356 @@ describe('BlockConfig', () => {
         ],
       });
       expect(isValid).toBe(false);
-      expect(validate.errors).toHaveLength(1);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
-          "keyword": "required",
-          "params": { "missingProperty": "type" },
-        });
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
+            "keyword": "required",
+            "params": { "missingProperty": "type" },
+          })
+        ])
+      );
+    });
+
+    it('throw an error if UI property type string not contains minLength', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: {
+                sections: [
+                  {
+                    "title": "Paramètres",
+                    "properties": {
+                      "inseeCode": {
+                        "type": "string",
+                        "title": "a title",
+                        "description": "bla bla",
+                        "maxLength": 10
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            templates: [],
+            external: {
+              parameters: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
+            "keyword": "required",
+            "params": { "missingProperty": "minLength" },
+          })
+        ])
+      )
+    });
+
+    it('throw an error if UI property type string not contains maxLength', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: {
+                sections: [
+                  {
+                    "title": "Paramètres",
+                    "properties": {
+                      "inseeCode": {
+                        "type": "string",
+                        "title": "a title",
+                        "description": "bla bla",
+                        "minLength": 10
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            templates: [],
+            external: {
+              parameters: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
+            "keyword": "required",
+            "params": { "missingProperty": "maxLength" },
+          })
+        ])
+      )
+    });
+
+    it('throw an error if UI property type number not contains minimum', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: {
+                sections: [
+                  {
+                    "title": "Paramètres",
+                    "properties": {
+                      "size": {
+                        "type": "number",
+                        "title": "a title",
+                        "description": "bla bla",
+                        "maximum": 10
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            templates: [],
+            external: {
+              parameters: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']",
+            "keyword": "required",
+            "params": { "missingProperty": "minimum" },
+          })
+        ])
+      )
+    });
+
+    it('throw an error if UI property type number not contains maximum', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: {
+                sections: [
+                  {
+                    "title": "Paramètres",
+                    "properties": {
+                      "size": {
+                        "type": "number",
+                        "title": "a title",
+                        "description": "bla bla",
+                        "minimum": 10
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            templates: [],
+            external: {
+              parameters: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']",
+            "keyword": "required",
+            "params": { "missingProperty": "maximum" },
+          })
+        ])
+      )
+    });
+
+    it('throw an error if UI property type boolean contains maximum', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: {
+                sections: [
+                  {
+                    "title": "Paramètres",
+                    "properties": {
+                      "isVisible": {
+                        "type": "boolean",
+                        "title": "a title",
+                        "description": "bla bla",
+                        "maximum": 10
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            templates: [],
+            external: {
+              parameters: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['isVisible'].type",
+            "keyword": "enum",
+            "params": { "allowedValues": [ "number" ] },
+          })
+        ])
+      )
+    });
+
+    it('throw an error if UI property type number contains maxLength', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: {
+                sections: [
+                  {
+                    "title": "Paramètres",
+                    "properties": {
+                      "size": {
+                        "type": "number",
+                        "title": "a title",
+                        "description": "bla bla",
+                        "maximum": 10,
+                        "minimum": 0,
+                        "maxLength": 10,
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            templates: [],
+            external: {
+              parameters: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size'].type",
+            "keyword": "enum",
+            "params": { "allowedValues": [ "string" ] },
+          })
+        ])
+      )
+    });
+
+
+    it('throw an error if UI property type string contains maximum', () => {
+      const isValid = validate({
+        name: 'cms-block-provider-empty',
+        type: 'Display',
+        labels: [],
+        configurations: [
+          {
+            version: '1.0.0',
+            endpoint: {
+              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+              method: 'GET',
+              pure: false,
+              parameters: [],
+              ui: {
+                sections: [
+                  {
+                    "title": "Paramètres",
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "title": "a title",
+                        "description": "bla bla",
+                        "maximum": 10,
+                        "minLength": 0,
+                        "maxLength": 10,
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            templates: [],
+            external: {
+              parameters: []
+            },
+          },
+        ],
+      });
+      expect(isValid).toBe(false);
+      expect(validate.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['label'].type",
+            "keyword": "enum",
+            "params": { "allowedValues": [ "number" ] },
+          })
+        ])
+      )
     });
 
     ['array', 'object', 'null'].forEach(type => {

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -83,93 +83,81 @@
       "type": "object",
       "title": "UI configuration contract group",
       "description": "Define configuration set contract",
-      "required": [ "id", "form" ],
+      "required": [ "properties", "title" ],
       "properties": {
-        "id": {
-          "type": "string",
-          "description": "Uniq id of form tab to expose in PageBuilder"
+        "title": {
+          "description": "Title of form tab to display PageBuilder",
+          "type": "string"
         },
-        "form": {
+        "description": {
+          "description": "Description of form tab. Example: 'Server administration configuration'",
+          "type": "string"
+        },
+        "properties": {
+          "minProperties": 1,
           "type": "object",
-          "description": "Define form tab to expose in PageBuilder",
-          "required": [ "properties", "title" ],
-          "properties": {
-            "title": {
-              "description": "Title of form tab to display PageBuilder",
-              "type": "string"
-            },
-            "description": {
-              "description": "Description of form tab. Example: 'Server administration configuration'",
-              "type": "string"
-            },
-            "properties": {
-              "minProperties": 1,
-              "type": "object",
-              "additionalProperties": {
-                "allOf": [
-                  {
-                    "properties": {
-                      "type": {
-                        "description": "basic type of configuration field",
-                        "anyOf": [
-                          {
-                            "$ref": "#/definitions/UIPropertyBasicTypes"
-                          }
-                        ]
-                      },
-                      "title": {
-                        "description": "Label of configuration field",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "description of configuration field (e.g. to display in pophover)",
-                        "type": "string"
-                      },
-                      "maximum": {
-                        "type": "number"
-                      },
-                      "minimum": {
-                        "type": "number"
-                      },
-                      "maxLength": {
-                        "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
-                      },
-                      "minLength": {
-                        "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
-                      },
-                      "pattern": {
-                        "type": "string",
-                        "format": "regex"
-                      },
-                      "enum": {
-                        "type": "array",
-                        "items": {
-                          "type": [ "string", "number" ]
-                        },
-                        "minItems": 1,
-                        "uniqueItems": true
-                      },
-                      "format": {
-                        "description": "subset of html input type to describe input behavior",
-                        "anyOf": [
-                          {
-                            "$ref": "#/definitions/UIInputFormat"
-                          }
-                        ]
-                      },
-                      "default": {}
+          "additionalProperties": {
+            "allOf": [
+              {
+                "properties": {
+                  "type": {
+                    "description": "basic type of configuration field",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/UIPropertyBasicTypes"
+                      }
+                    ]
+                  },
+                  "title": {
+                    "description": "Label of configuration field",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "description of configuration field",
+                    "type": "string"
+                  },
+                  "maximum": {
+                    "type": "number"
+                  },
+                  "minimum": {
+                    "type": "number"
+                  },
+                  "maxLength": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                  },
+                  "minLength": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                  },
+                  "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                  },
+                  "enum": {
+                    "type": "array",
+                    "items": {
+                      "type": [ "string", "number" ]
                     },
-                    "required": [ "type", "title" ]
-                  }
-                ]
+                    "minItems": 1,
+                    "uniqueItems": true
+                  },
+                  "format": {
+                    "description": "subset of html input type to describe input behavior",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/UIInputFormat"
+                      }
+                    ]
+                  },
+                  "default": {}
+                },
+                "required": [ "type", "title" ]
               }
-            },
-            "required": {
-              "description": "list mandatory configuration field",
-              "$ref": "http://json-schema.org/draft-06/schema#/definitions/stringArray"
-            }
-          },
-          "additionalProperties": false
+            ]
+          }
+        },
+        "required": {
+          "description": "list mandatory configuration field",
+          "$ref": "http://json-schema.org/draft-06/schema#/definitions/stringArray"
         }
       },
       "additionalProperties": false
@@ -177,9 +165,16 @@
     "UISchema": {
       "title": "UISchema declaration",
       "description": "Specify in UISchema format how the parameters should be rendered in PageBuilder.",
-      "type": "array",
-      "items": { "$ref": "#/definitions/UISection" },
-      "default": []
+      "type": "object",
+      "properties": {
+        "sections": {
+          "type": "array",
+          "description": "TODO",
+          "items": { "$ref": "#/definitions/UISection" },
+          "default": []
+        }
+      },
+      "additionalProperties": false
     },
     "BlockProviderConfig": {
       "definitions": {},

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -239,7 +239,7 @@
       "properties": {
         "sections": {
           "type": "array",
-          "description": "TODO",
+          "description": "list of configuration set contract. Allows configuration to be consolidated by interest",
           "items": { "$ref": "#/definitions/UISection" },
           "default": []
         }

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -150,7 +150,8 @@
                   },
                   "default": {}
                 },
-                "required": [ "type", "title" ]
+                "required": [ "type", "title", "description" ],
+                "additionalProperties": false
               }
             ]
           }

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -58,6 +58,131 @@
         "meteo/meteo--detail"
       ]
     },
+    "Props": {
+      "type": "object",
+      "required": ["type", "description", "title"],
+      "properties": {
+        "type": {
+          "description": "basic type of configuration field",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UIPropertyBasicTypes"
+            }
+          ]
+        },
+        "title": {
+          "description": "Label of configuration field",
+          "type": "string"
+        },
+        "description": {
+          "description": "description of configuration field",
+          "type": "string"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maxLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "pattern": {
+          "type": "string",
+          "format": "regex"
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": [ "string", "number" ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "format": {
+          "description": "subset of html input type to describe input behavior",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UIInputFormat"
+            }
+          ]
+        },
+        "default": {}
+      },
+      "dependencies": {
+        "minimum": {
+          "properties": {
+            "type": {
+              "enum": ["number"]
+            }
+          }
+        },
+        "maximum": {
+          "properties": {
+            "type": {
+              "enum": ["number"]
+            }
+          }
+        },
+        "maxLength": {
+          "properties": {
+            "type": {
+              "enum": ["string"]
+            }
+          }
+        },
+        "format": {
+          "properties": {
+            "type": {
+              "enum": ["string"]
+            }
+          }
+        },
+        "enum": {
+          "properties": {
+            "type": {
+              "enum": ["string", "number"]
+            }
+          }
+        },
+        "pattern": {
+          "properties": {
+            "type": {
+              "enum": ["string"]
+            }
+          }
+        },
+        "minLength": {
+          "properties": {
+            "type": {
+              "enum": ["string"]
+            }
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "type": {"enum": ["boolean"] }
+          }
+        },
+        {
+          "properties": {
+            "type": {"enum": ["string"] }
+          },
+          "required": ["minLength", "maxLength"]
+        },
+        {
+          "properties": {
+            "type": {"enum": ["number"] }
+          },
+          "required": ["minimum", "maximum"]
+        }
+      ]
+    },
     "BlockType": {
       "$id": "/properties/type",
       "type": "string",
@@ -74,10 +199,10 @@
       "enum": ["twig", "mustache", "php-twig"]
     },
     "UIPropertyBasicTypes": {
-      "enum": [ "integer", "number", "string", "boolean" ]
+      "enum": [ "number", "string", "boolean" ]
     },
     "UIInputFormat": {
-      "enum": [ "email", "text", "password", "date" ]
+      "enum": [ "email", "text", "date" ]
     },
     "UISection": {
       "type": "object",
@@ -93,72 +218,16 @@
           "description": "Description of form tab. Example: 'Server administration configuration'",
           "type": "string"
         },
+        "required": {
+          "description": "list mandatory configuration field",
+          "$ref": "http://json-schema.org/draft-06/schema#/definitions/stringArray"
+        },
         "properties": {
           "minProperties": 1,
           "type": "object",
           "additionalProperties": {
-            "allOf": [
-              {
-                "properties": {
-                  "type": {
-                    "description": "basic type of configuration field",
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/UIPropertyBasicTypes"
-                      }
-                    ]
-                  },
-                  "title": {
-                    "description": "Label of configuration field",
-                    "type": "string"
-                  },
-                  "description": {
-                    "description": "description of configuration field",
-                    "type": "string"
-                  },
-                  "maximum": {
-                    "type": "number"
-                  },
-                  "minimum": {
-                    "type": "number"
-                  },
-                  "maxLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
-                  },
-                  "minLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
-                  },
-                  "pattern": {
-                    "type": "string",
-                    "format": "regex"
-                  },
-                  "enum": {
-                    "type": "array",
-                    "items": {
-                      "type": [ "string", "number" ]
-                    },
-                    "minItems": 1,
-                    "uniqueItems": true
-                  },
-                  "format": {
-                    "description": "subset of html input type to describe input behavior",
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/UIInputFormat"
-                      }
-                    ]
-                  },
-                  "default": {}
-                },
-                "required": [ "type", "title", "description" ],
-                "additionalProperties": false
-              }
-            ]
+            "$ref": "#/definitions/Props"
           }
-        },
-        "required": {
-          "description": "list mandatory configuration field",
-          "$ref": "http://json-schema.org/draft-06/schema#/definitions/stringArray"
         }
       },
       "additionalProperties": false

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -73,14 +73,113 @@
         "The template engine to use to render this Block. *twig* is deprecated, always use 'mustache' instead, see: https://mustache.github.io",
       "enum": ["twig", "mustache", "php-twig"]
     },
-    "UISchema": {
+    "UIPropertyBasicTypes": {
+      "enum": [ "integer", "number", "string", "boolean" ]
+    },
+    "UIInputFormat": {
+      "enum": [ "email", "text", "password", "date" ]
+    },
+    "UISection": {
       "type": "object",
+      "title": "UI configuration contract group",
+      "description": "Define configuration set contract",
+      "required": [ "id", "form" ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Uniq id of form tab to expose in PageBuilder"
+        },
+        "form": {
+          "type": "object",
+          "description": "Define form tab to expose in PageBuilder",
+          "required": [ "properties", "title" ],
+          "properties": {
+            "title": {
+              "description": "Title of form tab to display PageBuilder",
+              "type": "string"
+            },
+            "description": {
+              "description": "Description of form tab. Example: 'Server administration configuration'",
+              "type": "string"
+            },
+            "properties": {
+              "minProperties": 1,
+              "type": "object",
+              "additionalProperties": {
+                "allOf": [
+                  {
+                    "properties": {
+                      "type": {
+                        "description": "basic type of configuration field",
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/UIPropertyBasicTypes"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "description": "Label of configuration field",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "description of configuration field (e.g. to display in pophover)",
+                        "type": "string"
+                      },
+                      "maximum": {
+                        "type": "number"
+                      },
+                      "minimum": {
+                        "type": "number"
+                      },
+                      "maxLength": {
+                        "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                      },
+                      "minLength": {
+                        "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                      },
+                      "pattern": {
+                        "type": "string",
+                        "format": "regex"
+                      },
+                      "enum": {
+                        "type": "array",
+                        "items": {
+                          "type": [ "string", "number" ]
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                      },
+                      "format": {
+                        "description": "subset of html input type to describe input behavior",
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/UIInputFormat"
+                          }
+                        ]
+                      },
+                      "default": {}
+                    },
+                    "required": [ "type", "title" ]
+                  }
+                ]
+              }
+            },
+            "required": {
+              "description": "list mandatory configuration field",
+              "$ref": "http://json-schema.org/draft-06/schema#/definitions/stringArray"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "UISchema": {
       "title": "UISchema declaration",
-      "description":
-        "Specify in UISchema format how the parameters should be rendered in PageBuilder. See https://github.com/mozilla-services/react-jsonschema-form",
-      "properties": {},
-      "additionalProperties": true,
-      "maxProperties": 100
+      "description": "Specify in UISchema format how the parameters should be rendered in PageBuilder.",
+      "type": "array",
+      "items": { "$ref": "#/definitions/UISection" },
+      "default": []
     },
     "BlockProviderConfig": {
       "definitions": {},


### PR DESCRIPTION
### Evolution NON compatible du schema de configuration de block (BlockConfig.json)

Non compatible car la partie ui est maintenant beaucoup plus contraignante.
A Discuter mais nous devrions donc normalement monter de version de schema _(2.x => 3.x)_

### convention sur configuration pour la génération des champs de formulaire

Le principe de ce premier schema de configuration de `ui` est de couvrir les champs de saisie les plus élémentaires sur la seule base d'une configuration json-schema. 

Il est ainsi proposé un mapping de configuration json-schema vers champs de saisie sur une base de convention _(sur configuration)_.

La surcharge avec des composants de saisie plus spécialisé sera ainsi permise via de la configuration _(voir plus bas sur la spécialisation de composant)_.

### Sous ensemble json-schema

Nous avons dû restreindre les possibilité de configuration json-schema vis à vis des types pour rendre comprehensible ce mapping config vers champs de saisi _(json-schema permet d'exprimer trop de chose, et des choses trop complexes sinon)_.

Seule les types string, number, boolan sont ainsi supportés.

* l'integration des types array est en construction  et *devra* être supporté
* le type object sera aussi envisagé mais encore plus tard, l'usage etant essentiellement  d'enforcer la validation.

### Champ de saisie élémentaires

Le champs de saisie élémentaires suivants sont pris en compte :
* texte simple _(`"type": "string"  "format": "text"` - c'est le format par defaut pour le type string )_
  * avec type d'input spécialisé: `format": email`
  * avec les contraintes **REQUIRED** : `regex`, `max/minLength`
* numerique simple _(`"type": "number" `)_
  * avec les contraintes **REQUIRED** : `maximum/minimum`
* select simple string ou number _(`"type": "string" enum: []` )_
* checkbox _(`"type": "boolean"` )_
* calendrier _(date uniquement pour l'instant)_ _(`"type": "string" "format": "date"` )_

Remarques:
* les formats de date `datetime-local`, `time` ne sont pas encore proposés mais devraient l'être plus tard

### Type Array

Le types array n'est pas encore proposé.

Des pistes sont creuser pour gérer les tableau de manière dynamique (bouton d'ajout/suppression permettant de rajouter des lignes de champs de saisie).

De ce fait les saisie suivantes ne sont pas possible actuellement:
* multi checkbox => plusieurs champs en checkbox peuvent remplacer ce champ de saisie
* multi select => obligation de passer en mode string oui expression pour l'instant.

### Type object

Le types object n'est pas encore proposé.
Son seul usage prévu serait d'enforcer les types échangés avec des input-widget au travers une definition json-schema classique

### Etude sur la configuration de composant de saisie spécialisé

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
**!!! CETTE PR NE PREND PAS EN COMPTE NI LA SPECIALISATION DU RENDU, NI LES WIDGET !!!**
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

A titre d'information, et d'exemple DE CE QUE POURRAIT ETRE la conf de widget, voici 
une PROPOSITION de champs `x-widget`

```
{
  ui: {
    "sections": [
      {
        "title": "Technique",
        "properties": {
          "edito": {
            "type": "string",
            "title": "filtre article",
            "description": "",
            "x-widget": {
              "name": "bp-filter-article-widget",
              "version": "2",
              "configuration": {
                "operators": [
                  {
                    "operator_id": 'is',
                    "label": 'is',
                    "argumentType_id": 'smallString'
                  },
                  {
                    "operator_id": 'contains',
                    "label": 'Contains',
                    "argumentType_id": 'smallString'
                  },
                  {
                    "operator_id": 'isLowerThan',
                    "label": '<',
                    "argumentType_id": 'number'
                  },
                  {
                    "operator_id": 'isEqualTo',
                    "label": '=',
                    "argumentType_id": 'number'
                  },
                  {
                    "operator_id": 'isHigherThan',
                    "label": '>',
                    "argumentType_id": 'number'
                  },
                  {
                    "operator_id": 'is_date',
                    "label": 'is',
                    "argumentType_id": 'datepicker'
                  },
                  {
                    "operator_id": 'is_color',
                    "label": 'is',
                    "argumentType_id": 'colorpicker'
                  }
                ],
                "types": [
                  {
                    "type_id": 'int',
                    "operator_ids": [
                      'isLowerThan',
                      'isEqualTo',
                      'isHigherThan'
                    ]
                  },
                  {
                    "type_id": 'string',
                    "operator_ids": [
                      'is',
                      'contains'
                    ]
                  },
                  {
                    "type_id": 'datetime',
                    "operator_ids": [
                      'is_date',
                      'isBetween_date'
                    ]
                  },
                  {
                    "type_id": 'color',
                    "operator_ids": [
                      'isBrighterThan',
                      'isDarkerThan',
                      'is_color'
                    ]
                  }
                ],
                "targets": [
                  {
                    target_id: 'article.title',
                    "label": 'Article title',
                    "type_id": 'string'
                  },
                  {
                    target_id: 'article.videoCount',
                    "label": 'Article video count',
                    "type_id": 'int'
                  },
                  {
                    target_id: 'article.publishingAt',
                    "label": 'Article publish date',
                    "type_id": 'datetime'
                  },
                  {
                    target_id: 'article.color',
                    "label": 'Article main color',
                    "type_id": 'color'
                  }
                ],
                "argumentTypes": [
                  {
                    "argumentType_id": 'smallString',
                    "component": {
                      "type": "string",
                      "maxLength": 20
                    }
                  },
                  {
                    "argumentType_id": 'datapicker',
                    "component": {
                      "type": "string",
                      "format": "date"
                    }
                  },
                  {
                    "argumentType_id": 'colorpicker',
                    "component": {
                      "type": "string",
                      "pattern": "#([0-9A-F]{6})",
                      "x-widget": {
                        "name": "color-input",
                        "version": "1"
                      }
                    }
                  },
                  {
                    "argumentType_id": 'number',
                    "component": {
                      "type": "number",
                      "format": "range",
                      minimum: 0,
                      maximum: 100
                    }
                  }
                ]
              }
            }
          }
        }
      }
    ]
  }
}
```
