### PR TITLE
fix(schema): enable widget and component configuration

### DIFF
--- a/packages/schemas/BlockConfig.test.js
+++ b/packages/schemas/BlockConfig.test.js
@@ -721,6 +721,38 @@ describe('BlockConfig', () => {
         )
       });
 
+      it('throw if component has both component and widget', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size", {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "x-ui-configuration": {
+                "widget": {
+                  "name": "my-widget",
+                  "version": "1.0"
+                },
+                "component": {
+                  "name": "slider"
+                }
+              }
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']['x-ui-configuration']",
+              "keyword": "oneOf"
+            })
+          ])
+        )
+      });
+
       it('throw if component has invalid property', () => {
         const isValid = validate(
           configurationFactoryByUiSectionProps(

--- a/packages/schemas/BlockConfig.test.js
+++ b/packages/schemas/BlockConfig.test.js
@@ -80,7 +80,25 @@ describe('BlockConfig', () => {
                       "title": "Nombre d'article",
                       "description": "Correspond au nombre d'article à aficher sur la première page d'une liste d'article",
                       "minLength": 0,
-                      "maxLength": 10
+                      "maxLength": 100,
+                      "x-ui-configuration": {
+                        "component": {
+                          "name": "slider"
+                        }
+                      }
+                    },
+                    "filter": {
+                      "type": "string",
+                      "title": "Filtre de récupération des articles",
+                      "description": "filtre au format ui-predicate (configuration edition filter) decrivant les conditions de récupération des articles automatiques",
+                      "minLength": 0,
+                      "maxLength": 1000,
+                      "x-ui-configuration": {
+                        "widget": {
+                          "name": "article-filter-ui-predicate",
+                          "version": "1"
+                        }
+                      }
                     }
                   },
                   required: [ 'inseeCode', 'size' ]
@@ -163,134 +181,50 @@ describe('BlockConfig', () => {
       'https://raw.githubusercontent.com/Ouest-France/platform/master/packages/schemas/BlockConfig.json'
     );
 
-    it('throw an error if UI section has no properties', () => {
-
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
+    const configurationFactoryByUI = (ui) => ({
+      name: 'cms-block-provider-empty',
         type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "param",
-                    "properties": {}
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: [],
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toHaveLength(1);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties",
-          "keyword": "minProperties",
-        });
+      labels: [],
+      configurations: [
+      {
+        version: '1.0.0',
+        endpoint: {
+          url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
+          method: 'GET',
+          pure: false,
+          parameters: [],
+          ui
+        },
+        templates: [],
+        external: {
+          parameters: [],
+        },
+      },
+    ],
     });
 
-    it('throw an error if UI section has unknown properties', () => {
+    it('throw if UI has unknown properties', () => {
+      const isValid = validate(configurationFactoryByUI(
+        {
+          "unknownProperty": false,
+          sections: [
+            {
+              "title": "Technique",
+              "properties": {
+                "role": {
+                  "description": "Role à qui reviendra la charge d'éditer ce block",
+                  "type": "string",
+                  "title": "Role",
+                  "enum": ["ADMIN", "WEBMASTER", "ANONYME"],
+                  "minLength": 0,
+                  "maxLength": 10
+                }
+              },
+              required: ['role']
+            }
+          ]
+        }));
 
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Technique",
-                    "unknownProperty": false,
-                    "properties": {
-                      "role": {
-                        "description": "Role à qui reviendra la charge d'éditer ce block",
-                        "type": "string",
-                        "title": "Role",
-                        "enum": ["ADMIN", "WEBMASTER", "ANONYME"],
-                        "minLength": 0,
-                        "maxLength": 10
-                      }
-                    },
-                    required: [ 'role' ]
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: [],
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toHaveLength(1);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui.sections[0]",
-          "keyword": "additionalProperties",
-          "params": { "additionalProperty": "unknownProperty" } });
-    });
-
-    it('throw an error if UI has unknown properties', () => {
-
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                "unknownProperty": false,
-                sections: [
-                  {
-                    "title": "Technique",
-                    "properties": {
-                      "role": {
-                        "description": "Role à qui reviendra la charge d'éditer ce block",
-                        "type": "string",
-                        "title": "Role",
-                        "enum": ["ADMIN", "WEBMASTER", "ANONYME"],
-                        "minLength": 0,
-                        "maxLength": 10
-                      }
-                    },
-                    required: [ 'role' ]
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: [],
-            },
-          },
-        ],
-      });
       expect(isValid).toBe(false);
       expect(validate.errors).toHaveLength(1);
       expect(validate.errors[0]).toMatchObject(
@@ -299,567 +233,521 @@ describe('BlockConfig', () => {
           "params": { "additionalProperty": "unknownProperty" } });
     });
 
-    it('throw an error if UI section property has unknown properties', () => {
-
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
+    describe('throw if UI section is invalid', () => {
+      it('throw if UI section has no properties', () => {
+        const isValid = validate(configurationFactoryByUI(
           {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Technique",
-                    "properties": {
-                      "role": {
-                        "description": "Role à qui reviendra la charge d'éditer ce block",
-                        "type": "string",
-                        "title": "Role",
-                        "enum": ["ADMIN", "WEBMASTER", "ANONYME"],
-                        "minLength": 0,
-                        "maxLength": 10,
-                        "unknownProperty": false
-                      }
-                    },
-                    required: [ 'role' ]
-                  }
-                ]
+            sections: [
+              {
+                "title": "param",
+                "properties": {}
               }
-            },
-            templates: [],
-            external: {
-              parameters: [],
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toHaveLength(1);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['role']",
-          "keyword": "additionalProperties",
-          "params": { "additionalProperty": "unknownProperty" } });
-    });
+            ]
+          }));
 
-    it('throw an error if UI section has unexpected property', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
+        expect(isValid).toBe(false);
+        expect(validate.errors).toHaveLength(1);
+        expect(validate.errors[0]).toMatchObject(
+          { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties",
+            "keyword": "minProperties",
+          });
+      });
+
+      it('throw if UI section has unknown properties', () => {
+        const isValid = validate(configurationFactoryByUI(
           {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    type: "string",
-                    title: "insee",
-                    other: "a value"
+            sections: [
+              {
+                "title": "Technique",
+                "unknownProperty": false,
+                "properties": {
+                  "role": {
+                    "description": "Role à qui reviendra la charge d'éditer ce block",
+                    "type": "string",
+                    "title": "Role",
+                    "enum": ["ADMIN", "WEBMASTER", "ANONYME"],
+                    "minLength": 0,
+                    "maxLength": 10
                   }
-                ]
+                },
+                required: ['role']
               }
-            },
-            templates: [],
-            external: {
-              parameters: [],
-              ui: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui.sections[0]",
-          "keyword": "additionalProperties",
-        });
-    });
+            ]
+          }));
 
-    it('throw an error if UI property has no title', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
+        expect(isValid).toBe(false);
+        expect(validate.errors).toHaveLength(1);
+        expect(validate.errors[0]).toMatchObject(
+          { "dataPath": ".configurations[0].endpoint.ui.sections[0]",
+            "keyword": "additionalProperties",
+            "params": { "additionalProperty": "unknownProperty" } });
+      });
+
+      it('throw if UI section has unexpected property', () => {
+        const isValid = validate(configurationFactoryByUI(
           {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "inseeCode": {
-                        "type": "string",
-                        "description": "bla bla",
-                        "minLength": 0,
-                        "maxLength": 10
-                      }
-                    }
-                  }
-                ]
+            sections: [
+              {
+                type: "string",
+                title: "insee",
+                other: "a value"
               }
-            },
-            templates: [],
-            external: {
-              parameters: [],
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toHaveLength(1);
-      expect(validate.errors[0]).toMatchObject(
-        { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
-          "keyword": "required",
-          "params": { "missingProperty": "title" },
-        });
-    });
+            ]
+          }
+        ));
 
-    it('throw an error if UI property has no type', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "inseeCode": {
-                        "title": "Code INSEE",
-                        "description": "bla bla",
-                        "minLength": 0,
-                        "maxLength": 10
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
-            "keyword": "required",
-            "params": { "missingProperty": "type" },
-          })
-        ])
-      );
-    });
-
-    it('throw an error if UI property type string not contains minLength', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "inseeCode": {
-                        "type": "string",
-                        "title": "a title",
-                        "description": "bla bla",
-                        "maxLength": 10
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
-            "keyword": "required",
-            "params": { "missingProperty": "minLength" },
-          })
-        ])
-      )
-    });
-
-    it('throw an error if UI property type string not contains maxLength', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "inseeCode": {
-                        "type": "string",
-                        "title": "a title",
-                        "description": "bla bla",
-                        "minLength": 10
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
-            "keyword": "required",
-            "params": { "missingProperty": "maxLength" },
-          })
-        ])
-      )
-    });
-
-    it('throw an error if UI property type number not contains minimum', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "size": {
-                        "type": "number",
-                        "title": "a title",
-                        "description": "bla bla",
-                        "maximum": 10
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']",
-            "keyword": "required",
-            "params": { "missingProperty": "minimum" },
-          })
-        ])
-      )
-    });
-
-    it('throw an error if UI property type number not contains maximum', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "size": {
-                        "type": "number",
-                        "title": "a title",
-                        "description": "bla bla",
-                        "minimum": 10
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']",
-            "keyword": "required",
-            "params": { "missingProperty": "maximum" },
-          })
-        ])
-      )
-    });
-
-    it('throw an error if UI property type boolean contains maximum', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "isVisible": {
-                        "type": "boolean",
-                        "title": "a title",
-                        "description": "bla bla",
-                        "maximum": 10
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['isVisible'].type",
-            "keyword": "enum",
-            "params": { "allowedValues": [ "number" ] },
-          })
-        ])
-      )
-    });
-
-    it('throw an error if UI property type number contains maxLength', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "size": {
-                        "type": "number",
-                        "title": "a title",
-                        "description": "bla bla",
-                        "maximum": 10,
-                        "minimum": 0,
-                        "maxLength": 10,
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size'].type",
-            "keyword": "enum",
-            "params": { "allowedValues": [ "string" ] },
-          })
-        ])
-      )
-    });
-
-
-    it('throw an error if UI property type string contains maximum', () => {
-      const isValid = validate({
-        name: 'cms-block-provider-empty',
-        type: 'Display',
-        labels: [],
-        configurations: [
-          {
-            version: '1.0.0',
-            endpoint: {
-              url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-              method: 'GET',
-              pure: false,
-              parameters: [],
-              ui: {
-                sections: [
-                  {
-                    "title": "Paramètres",
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "title": "a title",
-                        "description": "bla bla",
-                        "maximum": 10,
-                        "minLength": 0,
-                        "maxLength": 10,
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            templates: [],
-            external: {
-              parameters: []
-            },
-          },
-        ],
-      });
-      expect(isValid).toBe(false);
-      expect(validate.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['label'].type",
-            "keyword": "enum",
-            "params": { "allowedValues": [ "number" ] },
-          })
-        ])
-      )
-    });
-
-    ['array', 'object', 'null'].forEach(type => {
-      it(`throw an error if UI property has type ${type}`, () => {
-        const isValid = validate({
-          name: 'cms-block-provider-empty',
-          type: 'Display',
-          labels: [],
-          configurations: [
-            {
-              version: '1.0.0',
-              endpoint: {
-                url: 'http://cms-block-provider-meteo/weather-forecast/{inseeCode}',
-                method: 'GET',
-                pure: false,
-                parameters: [],
-                ui: {
-                  sections: [
-                    {
-                      "title": "Paramètres",
-                      "properties": {
-                        "inseeCode": {
-                          "type": type,
-                          "title": "Code INSEE"
-                        }
-                      }
-                    }
-                  ]
-                }
-              },
-              templates: [],
-              external: {
-                parameters: []
-              },
-            },
-          ],
-        });
         expect(isValid).toBe(false);
         expect(validate.errors[0]).toMatchObject(
-          { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode'].type",
-            "keyword": "enum"
+          { "dataPath": ".configurations[0].endpoint.ui.sections[0]",
+            "keyword": "additionalProperties",
           });
+      });
+    });
+
+    const configurationFactoryByUiSectionProps = (name, props) =>
+      configurationFactoryByUI(
+        {
+          sections: [
+            {
+              "title": "Technique",
+              "properties": {
+                [name]: props
+              },
+              required: [name]
+            }
+          ]
+        }
+      );
+
+    describe('throw if UI props is invalid', () => {
+
+      it('throw if UI props has unknown properties', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "role",
+            {
+              "description": "Role à qui reviendra la charge d'éditer ce block",
+              "type": "string",
+              "title": "Role",
+              "enum": ["ADMIN", "WEBMASTER", "ANONYME"],
+              "minLength": 0,
+              "maxLength": 10,
+              "unknownProperty": false
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toHaveLength(1);
+        expect(validate.errors[0]).toMatchObject(
+          { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['role']",
+            "keyword": "additionalProperties",
+            "params": { "additionalProperty": "unknownProperty" } });
+      });
+
+      it('throw if UI Props has no title', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "inseeCode",
+            {
+              "type": "string",
+              "description": "bla bla",
+              "minLength": 0,
+              "maxLength": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toHaveLength(1);
+        expect(validate.errors[0]).toMatchObject(
+          {
+            "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
+            "keyword": "required",
+            "params": {"missingProperty": "title"},
+          });
+      });
+
+      it('throw if UI Props has no type', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "inseeCode",
+            {
+              "title": "Code INSEE",
+              "description": "bla bla",
+              "minLength": 0,
+              "maxLength": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
+              "keyword": "required",
+              "params": {"missingProperty": "type"},
+            })
+          ])
+        );
+      });
+
+      it('throw if UI Props type string not contains minLength', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "inseeCode",
+            {
+              "type": "string",
+              "title": "a title",
+              "description": "bla bla",
+              "maxLength": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
+              "keyword": "required",
+              "params": {"missingProperty": "minLength"},
+            })
+          ])
+        )
+      });
+
+      it('throw if UI Props type string not contains maxLength', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "inseeCode",
+            {
+              "type": "string",
+              "title": "a title",
+              "description": "bla bla",
+              "minLength": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode']",
+              "keyword": "required",
+              "params": {"missingProperty": "maxLength"},
+            })
+          ])
+        )
+      });
+
+      it('throw if UI props type number not contains minimum', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size",
+            {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']",
+              "keyword": "required",
+              "params": {"missingProperty": "minimum"},
+            })
+          ])
+        )
+      });
+
+      it('throw if UI props type number not contains maximum', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size",
+            {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "minimum": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']",
+              "keyword": "required",
+              "params": {"missingProperty": "maximum"},
+            })
+          ])
+        )
+      });
+
+      it('throw if UI props type boolean contains maximum', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "isVisible",
+            {
+              "type": "boolean",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['isVisible'].type",
+              "keyword": "enum",
+              "params": {"allowedValues": ["number"]},
+            })
+          ])
+        )
+      });
+
+      it('throw if UI props type number contains maxLength', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size",
+            {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "maxLength": 10
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size'].type",
+              "keyword": "enum",
+              "params": {"allowedValues": ["string"]},
+            })
+          ])
+        )
+      });
+
+      it('throw if UI props type string contains maximum', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "label",
+            {
+              "type": "string",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minLength": 0,
+              "maxLength": 10,
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['label'].type",
+              "keyword": "enum",
+              "params": {"allowedValues": ["number"]},
+            })
+          ])
+        )
+      });
+
+      ['array', 'object', 'null'].forEach(type => {
+        it(`throw if UI props has type ${type}`, () => {
+          const isValid = validate(
+            configurationFactoryByUiSectionProps(
+              "inseeCode",
+              {
+                type,
+                "title": "Code INSEE"
+              }
+            ));
+
+          expect(isValid).toBe(false);
+          expect(validate.errors[0]).toMatchObject(
+            { "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['inseeCode'].type",
+              "keyword": "enum"
+            });
+        });
+      });
+    });
+
+    describe('throw if x-ui-configuration is invalid', () => {
+
+      it('throw if x-ui-configuration is empty', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size", {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "x-ui-configuration": {}
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']['x-ui-configuration']",
+              "keyword": "minProperties"
+            })
+          ])
+        )
+      });
+
+      it('throw if x-ui-configuration has invalid property', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size", {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "x-ui-configuration": {
+                "invalid": "test"
+              }
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']['x-ui-configuration']",
+              "keyword": "additionalProperties",
+              "params": { "additionalProperty": "invalid" }
+            })
+          ])
+        )
+      });
+
+      it('throw if widget has no version', () => {
+
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size", {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "x-ui-configuration": {
+                "widget": {
+                  "name": "test"
+                }
+              }
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']['x-ui-configuration'].widget",
+              "keyword": "required",
+              "params": {"missingProperty": "version"}
+            })
+          ])
+        )
+      });
+
+      it('throw if widget has no name', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size", {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "x-ui-configuration": {
+                "widget": {
+                  "version": "test"
+                }
+              }
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']['x-ui-configuration'].widget",
+              "keyword": "required",
+              "params": {"missingProperty": "name"}
+            })
+          ])
+        )
+      });
+
+      it('throw if component is empty', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size", {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "x-ui-configuration": {
+                "component": {
+                }
+              }
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']['x-ui-configuration'].component",
+              "keyword": "minProperties"
+            })
+          ])
+        )
+      });
+
+      it('throw if component has invalid property', () => {
+        const isValid = validate(
+          configurationFactoryByUiSectionProps(
+            "size", {
+              "type": "number",
+              "title": "a title",
+              "description": "bla bla",
+              "maximum": 10,
+              "minimum": 0,
+              "x-ui-configuration": {
+                "component": {
+                  "test": true
+                }
+              }
+            }
+          ));
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              "dataPath": ".configurations[0].endpoint.ui.sections[0].properties['size']['x-ui-configuration'].component",
+              "keyword": "additionalProperties",
+              "params": { "additionalProperty": "test" }
+            })
+          ])
+        )
       });
     });
   });

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -63,9 +63,19 @@
       "type": "object",
       "additionalProperties": false,
       "minProperties": 1,
+      "oneOf": [
+        {
+          "required": ["widget"],
+          "not": {"required": ["component"]}
+        },
+        {
+          "required": ["component"],
+          "not": {"required": ["widget"]}
+        }
+      ],
       "properties": {
         "widget": {
-          "description": "Specify widget to use. Widget is an external component hold by the current BlockProvider",
+          "description": "Specify widget to use. Widget is similar to a component except it is owned by a BlockProvider and is not part of the standard components available in the platform.",
           "additionalProperties": false,
           "required": ["name", "version"],
           "properties": {
@@ -80,7 +90,7 @@
           }
         },
         "component": {
-          "description": "allow to extend component configuration with representation aspect. Default component (choose by convention) may be force to specific component",
+          "description": "Allow to extend component configuration with representation parameters (example: placeholder) or to use another component than the default one.",
           "additionalProperties": false,
           "minProperties": 1,
           "properties": {

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -58,6 +58,41 @@
         "meteo/meteo--detail"
       ]
     },
+    "UIRepresentationPropertyConfiguration": {
+      "description": "Extend ui configuration field with pure UserInterface representation configuration (exemple specify placeholder from standard component, use slider component to set number instead simple number input, use color picker component to set string or yet use external widget).",
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "widget": {
+          "description": "Specify widget to use. Widget is an external component hold by the current BlockProvider",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "name of widget to use for this configuration field."
+            },
+            "version": {
+              "type": "string",
+              "description": "version of widget."
+            }
+          }
+        },
+        "component": {
+          "description": "allow to extend component configuration with representation aspect. Default component (choose by convention) may be force to specific component",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "name": {
+              "type": "string",
+              "enum": [ "slider" ],
+              "description": "name of component to use for this configuration field (example: slider)"
+            }
+          }
+        }
+      }
+    },
     "UIProperty": {
       "type": "object",
       "required": ["type", "description", "title"],
@@ -111,6 +146,7 @@
             }
           ]
         },
+        "x-ui-configuration": { "$ref": "#/definitions/UIRepresentationPropertyConfiguration" },
         "default": {}
       },
       "dependencies": {


### PR DESCRIPTION
This enabler is first step to declare that ui configuration field use specific component or widget. 
That's all. 

This PR will allow BO team to start integrating the first internal components and widget.

This component or widget can't yet be configured.
