### PR TITLE
feat(ui-schema): add x-section-type

### DIFF
--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -266,6 +266,10 @@
           "description": "list mandatory configuration field",
           "$ref": "http://json-schema.org/draft-06/schema#/definitions/stringArray"
         },
+        "x-section-type": {
+          "description": "Section type is used to categorize sections by impacting their rendering and access. This information is primarily intended for formatting forms  (shortcut icon, appearance, ...). This field is a free string and its processing is carried by contract consumers (PageBuilder)",
+          "type": "string"
+        },
         "properties": {
           "minProperties": 1,
           "type": "object",


### PR DESCRIPTION
Section type is used to categorize sections by impacting their rendering and access.

This information is primarily intended for formatting forms  (shortcut icon, appearance, ...) and does not impact validation.

This field is a free string and its processing is carried by contract consumers (PageBuilder).