### PR TITLE
chore(engine): remove references to (j)twig and mustache-amp engines

### DIFF
--- a/packages/documentation/defs.md
+++ b/packages/documentation/defs.md
@@ -254,11 +254,11 @@ The BlockType typology is :
 
 **Template engine**
 
-The template engine to use to render this Block. *twig* is deprecated, always use 'mustache' instead, see: https://mustache.github.io
+The template engine to use to render this Block. *php-twig* is deprecated and will be removed, use 'mustache' instead, see: https://mustache.github.io
 
 *Type*: string
 
-*Allowed values*: `twig` `mustache` `php-twig`
+*Allowed values*: `mustache` `php-twig`
 
 ### `definitionsUIPropertyBasicTypes`
 

--- a/packages/schemas/defs.json
+++ b/packages/schemas/defs.json
@@ -239,8 +239,8 @@
     "BlockTemplateEngine": {
       "type": "string",
       "title": "Template engine",
-      "description": "The template engine to use to render this Block. *twig* is deprecated, always use 'mustache' instead, see: https://mustache.github.io",
-      "enum": ["twig", "mustache", "mustache-amp", "php-twig"]
+      "description": "The template engine to use to render this Block. *php-twig* is deprecated and will be removed, use 'mustache' instead, see: https://mustache.github.io",
+      "enum": ["mustache", "php-twig"]
     },
     "UIPropertyBasicTypes": {
       "enum": [ "number", "string", "boolean" ]


### PR DESCRIPTION
Suppression de toutes références à l'engine `twig` : c'était l'engine twig fait par le java qui a été enlevé il y a qqs temps

Suppression de toutes références à l'engine `mustache-amp` : nous enlevons cet engine. Car la notion d'amp devient une notion de rendu (renderMode) et non de moteur de templating.

Et renforcement du warning (annonce de sa future suppression) concernant le moteur `php-twig` qu'on souhaite voir disparaitre au plus tôt.