### PR TITLE
Add Shared JS propertie

### DIFF
--- a/packages/schemas/BlockConfig.json
+++ b/packages/schemas/BlockConfig.json
@@ -179,6 +179,14 @@
                 "assets": {
                   "type": "object",
                   "properties": {
+                    "sharedJs": {
+                      "type": "array",
+                      "items": {
+                        "title": "Shared JS assets",
+                        "description": "JS Library or shared JS in page",
+                        "type": "string"
+                      }
+                    },
                     "js": {
                       "type": "array",
                       "items": {


### PR DESCRIPTION
You can shared js between 2 différents block in the same page.
All Js in this array conserve his name and is not squashed during the importation.